### PR TITLE
[AI-32] Add option for custom OpenAI-compatible endpoint

### DIFF
--- a/src/lib/ApiUtil.svelte
+++ b/src/lib/ApiUtil.svelte
@@ -1,6 +1,5 @@
 <script context="module" lang="ts">
   // This makes it possible to override the OpenAI API base URL in the .env file
-  const apiBase = import.meta.env.VITE_API_BASE || 'https://api.openai.com'
   const endpointCompletions = import.meta.env.VITE_ENDPOINT_COMPLETIONS || '/v1/chat/completions'
   const endpointGenerations = import.meta.env.VITE_ENDPOINT_GENERATIONS || '/v1/images/generations'
   const endpointModels = import.meta.env.VITE_ENDPOINT_MODELS || '/v1/models'
@@ -8,7 +7,6 @@
   const petalsBase = import.meta.env.VITE_PEDALS_WEBSOCKET || 'wss://chat.petals.dev'
   const endpointPetals = import.meta.env.VITE_PEDALS_WEBSOCKET || '/api/v2/generate'
 
-  export const getApiBase = ():string => apiBase
   export const getEndpointCompletions = ():string => endpointCompletions
   export const getEndpointGenerations = ():string => endpointGenerations
   export const getEndpointModels = ():string => endpointModels

--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -56,12 +56,12 @@
   let showSettingsModal
 
   let scDelay
-  const onStateChange = (...args:any) => {
+  const onStateChange = async (...args:any) => {
     if (!chat) return
     clearTimeout(scDelay)
-    setTimeout(() => {
+    setTimeout(async () => {
       if (chat.startSession) {
-        restartProfile(chatId)
+        await restartProfile(chatId)
         if (chat.startSession) {
           chat.startSession = false
           saveChatStore()
@@ -112,7 +112,7 @@
     setCurrentChat(chatId)
 
     chatRequest = new ChatRequest()
-    chatRequest.setChat(chat)
+    await chatRequest.setChat(chat)
 
     chat.lastAccess = Date.now()
     saveChatStore()
@@ -148,7 +148,7 @@
       console.log('Speech recognition not supported')
     }
     if (chat.startSession) {
-      restartProfile(chatId)
+      await restartProfile(chatId)
       if (chat.startSession) {
         chat.startSession = false
         saveChatStore()

--- a/src/lib/ChatOptionMenu.svelte
+++ b/src/lib/ChatOptionMenu.svelte
@@ -99,9 +99,9 @@
     showChatMenu = false
   }
 
-  const restartChatSession = () => {
+  const restartChatSession = async () => {
     close()
-    restartProfile(chatId)
+    await restartProfile(chatId)
     $checkStateChange++ // signal chat page to start profile
   }
 
@@ -125,17 +125,17 @@
     })
   }
 
-  const importProfileFromFile = (e) => {
+  const importProfileFromFile = async (e) => {
     const image = e.target.files[0]
     e.target.value = null
     const reader = new FileReader()
-    reader.onload = e => {
+    reader.onload = async (e) => {
       const json = (e.target || {}).result as string
       try {
         const profile = JSON.parse(json) as ChatSettings
-        profile.profileName = newNameForProfile(profile.profileName || '')
+        profile.profileName = await newNameForProfile(profile.profileName || '')
         profile.profile = null as any
-        saveCustomProfile(profile)
+        await saveCustomProfile(profile)
         openModal(PromptConfirm, {
           title: 'Profile Restored',
           class: 'is-info',
@@ -174,17 +174,17 @@
         <span class="menu-icon"><Fa icon={faGear}/></span> Chat Profile Settings
       </a>
       <hr class="dropdown-divider">
-      <a href={'#'} class:is-disabled={!hasActiveModels()} on:click|preventDefault={() => { hasActiveModels() && close(); hasActiveModels() && startNewChatWithWarning(chatId) }} class="dropdown-item">
+      <a href={'#'} class:is-disabled={!hasActiveModels()} on:click|preventDefault={async () => { hasActiveModels() && close(); hasActiveModels() && await startNewChatWithWarning(chatId) }} class="dropdown-item">
         <span class="menu-icon"><Fa icon={faSquarePlus}/></span> New Chat from Default
       </a>
-      <a href={'#'} class:is-disabled={!chatId} on:click|preventDefault={() => { chatId && close(); chatId && startNewChatFromChatId(chatId) }} class="dropdown-item">
+      <a href={'#'} class:is-disabled={!chatId} on:click|preventDefault={async () => { chatId && close(); chatId && await startNewChatFromChatId(chatId) }} class="dropdown-item">
         <span class="menu-icon"><Fa icon={faSquarePlusOutline}/></span> New Chat from Current
       </a>
       <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { if (chatId) close(); copyChat(chatId) }}>
         <span class="menu-icon"><Fa icon={faClone}/></span> Clone Chat
       </a>
       <hr class="dropdown-divider">
-      <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { if (chatId) restartChatSession() }}>
+      <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={async () => { if (chatId) await restartChatSession() }}>
         <span class="menu-icon"><Fa icon={faRotateRight}/></span> Restart Chat Session
       </a>
       <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { if (chatId) close(); clearMessages(chatId) }}>
@@ -231,4 +231,4 @@
 </div>
 
 <input style="display:none" type="file" accept=".json" on:change={(e) => importChatFromFile(e)} bind:this={chatFileInput} >
-<input style="display:none" type="file" accept=".json" on:change={(e) => importProfileFromFile(e)} bind:this={profileFileInput} >
+<input style="display:none" type="file" accept=".json" on:change={async (e) => await importProfileFromFile(e)} bind:this={profileFileInput} >

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -23,9 +23,9 @@ export class ChatRequest {
       controller:AbortController
       providerData: Record<string, any> = {}
 
-      setChat (chat: Chat) {
+      async setChat (chat: Chat) {
         this.chat = chat
-        this.chat.settings.model = this.getModel()
+        this.chat.settings.model = await this.getModel()
       }
 
       getChat (): Chat {
@@ -63,7 +63,7 @@ export class ChatRequest {
         // TODO:  Continue to break this method down to smaller chunks
         const _this = this
         const chat = getChat(_this.chat.id)
-        this.setChat(chat)
+        await this.setChat(chat)
         const chatSettings = _this.chat.settings
         const chatId = chat.id
         const imagePromptDetect = /^\s*(please|can\s+you|will\s+you)*\s*(give|generate|create|show|build|design)\s+(me)*\s*(an|a|set|a\s+set\s+of)*\s*([0-9]+|one|two|three|four)*\s+(image|photo|picture|pic)s*\s*(for\s+me)*\s*(of|[^a-z0-9]+|about|that\s+has|showing|with|having|depicting)\s+[^a-z0-9]*(.*)$/i
@@ -100,7 +100,7 @@ export class ChatRequest {
           }
         }
 
-        const model = this.getModel()
+        const model = await this.getModel()
         const modelDetail = getModelDetail(model)
         const maxTokens = getModelMaxTokens(model)
 
@@ -117,7 +117,7 @@ export class ChatRequest {
 
         // Inject hidden prompts if requested
         // if (!opts.summaryRequest)
-        this.buildHiddenPromptPrefixMessages(filtered, true)
+        await this.buildHiddenPromptPrefixMessages(filtered, true)
         const messagePayload = filtered
           .filter(m => { if (m.skipOnce) { delete m.skipOnce; return false } return true })
           .map(m => {
@@ -231,11 +231,11 @@ export class ChatRequest {
         return chatResponse
       }
 
-      getModel (): Model {
-        return this.chat.settings.model || getDefaultModel()
+      async getModel (): Promise<Model> {
+        return this.chat.settings.model || await getDefaultModel()
       }
 
-      private buildHiddenPromptPrefixMessages (messages: Message[], insert:boolean = false): Message[] {
+      private async buildHiddenPromptPrefixMessages (messages: Message[], insert:boolean = false): Promise<Message[]> {
         const chat = this.chat
         const chatSettings = chat.settings
         const hiddenPromptPrefix = mergeProfileFields(chatSettings, chatSettings.hiddenPromptPrefix).trim()
@@ -271,7 +271,7 @@ export class ChatRequest {
           }
           if (injectedPrompt) messages.pop()
         }
-        const model = this.getModel()
+        const model = await this.getModel()
         const messageDetail = getModelDetail(model)
         if (getLeadPrompt(this.getChat()).trim() && messageDetail.type === 'chat') {
           const lastMessage = (results.length && injectedPrompt && !isContinue) ? results[results.length - 1] : messages[messages.length - 1]
@@ -291,11 +291,12 @@ export class ChatRequest {
        * Gets an estimate of how many extra tokens will be added that won't be part of the visible messages
        * @param filtered
        */
-      private getTokenCountPadding (filtered: Message[], chat: Chat): number {
+      private async getTokenCountPadding (filtered: Message[], chat: Chat): Promise<number> {
+        const model = await this.getModel()
         let result = 0
         // add cost of hiddenPromptPrefix
-        result += this.buildHiddenPromptPrefixMessages(filtered)
-          .reduce((a, m) => a + countMessageTokens(m, this.getModel(), chat), 0)
+        result += (await this.buildHiddenPromptPrefixMessages(filtered))
+          .reduce((a, m) => a + countMessageTokens(m, model, chat), 0)
         // more here eventually?
         return result
       }
@@ -306,7 +307,7 @@ export class ChatRequest {
         const chatSettings = chat.settings
         const chatId = chat.id
         const reductionMode = chatSettings.continuousChat
-        const model = _this.getModel()
+        const model = await _this.getModel()
         const maxTokens = getModelMaxTokens(model) // max tokens for model
 
         const continueRequest = async () => {

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -7,13 +7,13 @@
   import { set as setOpenAI } from './providers/openai/util.svelte'
   import { hasActiveModels } from './Models.svelte'
 
-$: apiKey = $apiKeyStorage
+  $: apiKey = $apiKeyStorage
+  const openAiEndpoint = $globalStorage.openAiEndpoint || ''
+  let showPetalsSettings = $globalStorage.enablePetals
+  let pedalsEndpoint = $globalStorage.pedalsEndpoint
+  let hasModels = hasActiveModels()
 
-let showPetalsSettings = $globalStorage.enablePetals
-let pedalsEndpoint = $globalStorage.pedalsEndpoint
-let hasModels = hasActiveModels()
-
-onMount(() => {
+  onMount(() => {
     if (!$started) {
       $started = true
       // console.log('started', apiKey, $lastChatId, getChat($lastChatId))
@@ -24,20 +24,20 @@ onMount(() => {
       }
     }
     $lastChatId = 0
-})
+  })
 
-afterUpdate(() => {
+  afterUpdate(() => {
     hasModels = hasActiveModels()
     pedalsEndpoint = $globalStorage.pedalsEndpoint
     $checkStateChange++
-})
+  })
 
-const setPetalsEnabled = (event: Event) => {
+  const setPetalsEnabled = (event: Event) => {
     const el = (event.target as HTMLInputElement)
     setGlobalSettingValueByKey('enablePetals', !!el.checked)
     showPetalsSettings = $globalStorage.enablePetals
     hasModels = hasActiveModels()
-}
+  }
 
 </script>
 
@@ -54,7 +54,7 @@ const setPetalsEnabled = (event: Event) => {
       <strong>private</strong>. You can also close the browser tab and come back later to continue the conversation.
     </p>
     <p>
-      As an alternative to OpenAI, you can also use Petals swarm as a free API option for open chat models like Llama 2. 
+      As an alternative to OpenAI, you can enter your own OpenAI-compatabile API endpoint, or use Petals swarm as a free API option for open chat models like Llama 2. 
     </p>
     </div>
   </article>
@@ -100,6 +100,37 @@ const setPetalsEnabled = (event: Event) => {
     </div>
   </article>
 
+  <article class="message" class:is-danger={!hasModels} class:is-warning={!openAiEndpoint} class:is-info={openAiEndpoint}>
+    <div class="message-body">
+      Set the API BASE URI for alternative OpenAI-compatible endpoints:
+      <form
+        class="field has-addons has-addons-right"
+        on:submit|preventDefault={(event) => {
+          let val = ''
+          if (event.target && event.target[0].value) {
+            val = (event.target[0].value).trim()
+            setGlobalSettingValueByKey('openAiEndpoint', val)
+          } else {
+            setGlobalSettingValueByKey('openAiEndpoint', '')
+          }
+        }}
+      >
+        <p class="control is-expanded">
+          <input
+            aria-label="API BASE URI"
+            type="text"
+            class="input"
+            placeholder="https://api.openai.com"
+            value={openAiEndpoint}
+          />
+        </p>
+        <p class="control">
+          <button class="button is-info" type="submit">Save</button>
+        </p>
+      </form>
+    </div>
+  </article>
+  
   
   <article class="message" class:is-danger={!hasModels} class:is-warning={!showPetalsSettings} class:is-info={showPetalsSettings}>
     <div class="message-body">

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -36,24 +36,34 @@ export const supportedChatModelKeys = Object.keys({ ...supportedChatModels })
 const tpCache : Record<string, ModelDetail> = {}
 
 export const getModelDetail = (model: Model): ModelDetail => {
-    // First try to get exact match, then from cache
-    let r = lookupList[model] || tpCache[model]
-    if (r) return r
-    // If no exact match, find closest match
-    const k = Object.keys(lookupList)
-      .sort((a, b) => b.length - a.length) // Longest to shortest for best match
-      .find((k) => model.startsWith(k))
-    if (k) {
-      r = lookupList[k]
+  // Ensure model is a string for typesafety
+    if (typeof model !== 'string') {
+      console.warn('Invalid type for model:', model)
+      return unknownDetail
     }
-    if (!r) {
-      console.warn('Unable to find model detail for:', model, lookupList)
-      r = unknownDetail
+
+    // Attempt to fetch the model details directly from lookupList or cache
+    let result = lookupList[model] || tpCache[model]
+    if (result) {
+      return result
     }
+
+    // No direct match found, attempting to find the closest match
+    const sortedKeys = Object.keys(lookupList).sort((a, b) => b.length - a.length) // Longest to shortest for best match
+    const bestMatchKey = sortedKeys.find(key => model.startsWith(key))
+
+    if (bestMatchKey) {
+      result = lookupList[bestMatchKey]
+    } else {
+      console.warn('Unable to find model detail for:', model)
+      result = unknownDetail // Assign a default detail for undefined models
+    }
+
     // Cache it so we don't need to do that again
-    tpCache[model] = r
-    return r
+    tpCache[model] = result
+    return result
 }
+
 
 export const getEndpoint = (model: Model): string => {
     return getModelDetail(model).getEndpoint(model)

--- a/src/lib/NewChat.svelte
+++ b/src/lib/NewChat.svelte
@@ -4,17 +4,20 @@
   import { replace } from 'svelte-spa-router'
   import { getProfile, restartProfile } from './Profiles.svelte'
   import { getChatDefaults, hasChatSetting } from './Settings.svelte'
+  import { onMount } from 'svelte'
 
   // Create the new chat instance then redirect to it
 
-  const urlParams: URLSearchParams = new URLSearchParams($querystring)
-  const chatId = urlParams.has('p') ? addChat(getProfile(urlParams.get('p') || '')) : addChat()
-  Object.keys(getChatDefaults()).forEach(k => {
-    if (urlParams.has(k) && hasChatSetting(k as any)) {
-      setChatSettingValueByKey(chatId, k as any, urlParams.get(k))
-    }
-  })
+  onMount(async () => {
+    const urlParams: URLSearchParams = new URLSearchParams($querystring)
+    const chatId = urlParams.has('p') ? await addChat(await getProfile(urlParams.get('p') || '')) : await addChat()
+    Object.keys(getChatDefaults()).forEach(k => {
+      if (urlParams.has(k) && hasChatSetting(k as any)) {
+        setChatSettingValueByKey(chatId, k as any, urlParams.get(k))
+      }
+    })
   
-  restartProfile(chatId)
-  replace(`/chat/${chatId}`)
+    await restartProfile(chatId)
+    replace(`/chat/${chatId}`)
+  })
 </script>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -18,15 +18,17 @@ import {
       type ChatSortOption
 
 } from './Types.svelte'
-import { getModelDetail, getTokens } from './Models.svelte'
+import { getChatModelOptions, getModelDetail, getTokens } from './Models.svelte'
 
 // We are adding default model names explicitly here to avoid
 // circular dependencies. Alternative would be a big refactor,
 // which we want to avoid for now.
-export const getDefaultModel = (): Model => {
+export const getDefaultModel = async (): Promise<Model> => {
   if (!get(apiKeyStorage)) return 'stabilityai/StableBeluga2'
 
-  return 'gpt-3.5-turbo'
+  const models = await getChatModelOptions()
+
+  return models[0].text
 }
 
 export const getChatSettingList = (): ChatSetting[] => {

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
     import { applyProfile } from './Profiles.svelte'
     import { get } from 'svelte/store'
-    import { apiKeyStorage, getApiBase, getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
+    import { apiKeyStorage, getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
     import { faArrowDown91, faArrowDownAZ, faCheck, faThumbTack } from '@fortawesome/free-solid-svg-icons/index'
 // Setting definitions
 
@@ -25,10 +25,6 @@ import { getModelDetail, getTokens } from './Models.svelte'
 // which we want to avoid for now.
 export const getDefaultModel = (): Model => {
   if (!get(apiKeyStorage)) return 'stabilityai/StableBeluga2'
-
-  if (!getApiBase().includes('openai.com')) {
-        return 'openchat-3.5-0106.Q5_K_M.gguf'
-  }
 
   return 'gpt-3.5-turbo'
 }

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
     import { applyProfile } from './Profiles.svelte'
     import { get } from 'svelte/store'
-    import { apiKeyStorage, getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
+    import { apiKeyStorage, getApiBase, getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
     import { faArrowDown91, faArrowDownAZ, faCheck, faThumbTack } from '@fortawesome/free-solid-svg-icons/index'
 // Setting definitions
 
@@ -18,14 +18,19 @@ import {
       type ChatSortOption
 
 } from './Types.svelte'
-    import { getModelDetail, getTokens } from './Models.svelte'
+import { getModelDetail, getTokens } from './Models.svelte'
 
-const defaultModel:Model = 'gpt-3.5-turbo'
-const defaultModelPetals:Model = 'stabilityai/StableBeluga2'
-
+// We are adding default model names explicitly here to avoid
+// circular dependencies. Alternative would be a big refactor,
+// which we want to avoid for now.
 export const getDefaultModel = (): Model => {
-  if (!get(apiKeyStorage)) return defaultModelPetals
-  return defaultModel
+  if (!get(apiKeyStorage)) return 'stabilityai/StableBeluga2'
+
+  if (!getApiBase().includes('openai.com')) {
+        return 'openchat-3.5-0106.Q5_K_M.gguf'
+  }
+
+  return 'gpt-3.5-turbo'
 }
 
 export const getChatSettingList = (): ChatSetting[] => {
@@ -136,7 +141,8 @@ export const globalDefaults: GlobalSettings = {
   chatSort: 'created',
   openAICompletionEndpoint: '',
   enablePetals: false,
-  pedalsEndpoint: ''
+  pedalsEndpoint: '',
+  openAiEndpoint: 'https://api.openai.com'
 }
 
 const excludeFromProfile = {
@@ -720,6 +726,11 @@ const globalSettingsList:GlobalSetting[] = [
       {
         key: 'pedalsEndpoint',
         name: 'Petals API Endpoint',
+        type: 'text'
+      },
+      {
+        key: 'openAiEndpoint',
+        name: 'OpenAI API Endpoint',
         type: 'text'
       }
 ]

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -82,7 +82,7 @@
           ></div>
         {:else}
         <div class="level-item">
-          <button on:click={() => { $pinMainMenu = false; startNewChatWithWarning(activeChatId) }} class="panel-block button" title="Start new chat with default profile" class:is-disabled={!hasModels}
+          <button on:click={async () => { $pinMainMenu = false; await startNewChatWithWarning(activeChatId) }} class="panel-block button" title="Start new chat with default profile" class:is-disabled={!hasModels}
             ><span class="greyscale mr-1"><Fa icon={faSquarePlus} /></span> New chat</button>
           </div>
         {/if}

--- a/src/lib/Storage.svelte
+++ b/src/lib/Storage.svelte
@@ -14,7 +14,7 @@
   export const latestModelMap = persisted('latestModelMap', {} as Record<Model, Model>) // What was returned when a model was requested
   export const globalStorage = persisted('global', {} as GlobalSettings)
   const apiKeyFromEnv = import.meta.env.VITE_OPENAI_API_KEY || ''
-  const apiBaseUriFromEnv = import.meta.env.VITE_API_BASE || ''
+  const apiBaseUriFromEnv = import.meta.env.VITE_API_BASE || 'https://api.openai.com/v1'
   export const apiKeyStorage = persisted('apiKey', apiKeyFromEnv as string)
   export let checkStateChange = writable(0) // Trigger for Chat
   export let showSetChatSettings = writable(false) //
@@ -39,7 +39,7 @@
   }
 
   export const getApiBase = (): string => {
-    const endpoint = get(globalStorage).openAiEndpoint || apiBaseUriFromEnv || 'https://api.openai.com'
+    const endpoint = get(globalStorage).openAiEndpoint || apiBaseUriFromEnv
     return cleanApiBase(endpoint)
   }
 

--- a/src/lib/Storage.svelte
+++ b/src/lib/Storage.svelte
@@ -49,13 +49,13 @@
     return chatId
   }
 
-  export const addChat = (profile:ChatSettings|undefined = undefined): number => {
+  export const addChat = async (profile:ChatSettings|undefined = undefined): Promise<number> => {
     const chats = get(chatsStorage)
 
     // Find the max chatId
     const chatId = newChatID()
 
-    profile = JSON.parse(JSON.stringify(profile || getProfile(''))) as ChatSettings
+    profile = JSON.parse(JSON.stringify(profile || await getProfile(''))) as ChatSettings
     const nameMap = chats.reduce((a, chat) => { a[chat.name] = chat; return a }, {})
 
     // Add a new chat
@@ -73,7 +73,7 @@
     })
     chatsStorage.set(chats)
     // Apply defaults and prepare it to start
-    restartProfile(chatId)
+    await restartProfile(chatId)
     return chatId
   }
 
@@ -164,10 +164,10 @@
   }
   
   // Reset all setting to current profile defaults
-  export const resetChatSettings = (chatId, resetAll:boolean = false) => {
+  export const resetChatSettings = async (chatId, resetAll:boolean = false) => {
     const chats = get(chatsStorage)
     const chat = chats.find((chat) => chat.id === chatId) as Chat
-    const profile = getProfile(chat.settings.profile)
+    const profile = await getProfile(chat.settings.profile)
     const exclude = getExcludeFromProfile()
     if (resetAll) {
       // Reset to base defaults first, then apply profile
@@ -495,7 +495,7 @@
     return store.profiles || {}
   }
 
-  export const deleteCustomProfile = (chatId:number, profileId:string) => {
+  export const deleteCustomProfile = async (chatId:number, profileId:string) => {
     if (isStaticProfile(profileId)) {
       throw new Error('Sorry, you can\'t delete a static profile.')
     }
@@ -507,10 +507,10 @@
     }
     delete store.profiles[profileId]
     globalStorage.set(store)
-    getProfiles(true) // force update profile cache
+    await getProfiles(true) // force update profile cache
   }
 
-  export const saveCustomProfile = (profile:ChatSettings) => {
+  export const saveCustomProfile = async (profile:ChatSettings) => {
     const store = get(globalStorage)
     let profiles = store.profiles
     if (!profiles) {
@@ -533,7 +533,7 @@
     if (isStaticProfile(profile.profile)) {
       // throw new Error('Sorry, you can\'t modify a static profile. You can clone it though!')
       // Save static profile as new custom
-      profile.profileName = newNameForProfile(profile.profileName)
+      profile.profileName = await newNameForProfile(profile.profileName)
       profile.profile = uuidv4()
     }
     const clone = JSON.parse(JSON.stringify(profile)) // Always store a copy
@@ -549,7 +549,7 @@
     globalStorage.set(store)
     profile.isDirty = false
     saveChatStore()
-    getProfiles(true) // force update profile cache
+    await getProfiles(true) // force update profile cache
   }
 
   export const getChatSortOption = (): ChatSortOption => {

--- a/src/lib/Storage.svelte
+++ b/src/lib/Storage.svelte
@@ -14,6 +14,7 @@
   export const latestModelMap = persisted('latestModelMap', {} as Record<Model, Model>) // What was returned when a model was requested
   export const globalStorage = persisted('global', {} as GlobalSettings)
   const apiKeyFromEnv = import.meta.env.VITE_OPENAI_API_KEY || ''
+  const apiBaseUriFromEnv = import.meta.env.VITE_API_BASE || ''
   export const apiKeyStorage = persisted('apiKey', apiKeyFromEnv as string)
   export let checkStateChange = writable(0) // Trigger for Chat
   export let showSetChatSettings = writable(false) //
@@ -29,6 +30,17 @@
   
   export const getApiKey = (): string => {
     return get(apiKeyStorage)
+  }
+
+  // Avoid user input errors. Trailing slashes or "/v1" break
+  // the API.  So we clean it up here.
+  const cleanApiBase = (endpoint: string): string => {
+    return endpoint.replace(/\/v1$/, '').replace(/\/$/, '')
+  }
+
+  export const getApiBase = (): string => {
+    const endpoint = get(globalStorage).openAiEndpoint || apiBaseUriFromEnv || 'https://api.openai.com'
+    return cleanApiBase(endpoint)
   }
 
   export const newChatID = (): number => {

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -162,6 +162,7 @@ export type GlobalSettings = {
     openAICompletionEndpoint: string;
     enablePetals: boolean;
     pedalsEndpoint: string;
+    openAiEndpoint: string;
   };
 
   type SettingNumber = {

--- a/src/lib/Util.svelte
+++ b/src/lib/Util.svelte
@@ -122,15 +122,15 @@
     })
   }
 
-  export const startNewChatFromChatId = (chatId: number) => {
-    const newChatId = addChat(getChat(chatId).settings)
+  export const startNewChatFromChatId = async (chatId: number) => {
+    const newChatId = await addChat(getChat(chatId).settings)
     // go to new chat
     replace(`/chat/${newChatId}`)
   }
 
-  export const startNewChatWithWarning = (activeChatId: number|undefined, profile?: ChatSettings|undefined) => {
-    const newChat = () => {
-      const chatId = addChat(profile)
+  export const startNewChatWithWarning = async (activeChatId: number|undefined, profile?: ChatSettings|undefined) => {
+    const newChat = async () => {
+      const chatId = await addChat(profile)
       replace(`/chat/${chatId}`)
     }
     // if (activeChatId && getChat(activeChatId).settings.isDirty) {
@@ -146,7 +146,7 @@
     // } else {
     //   newChat()
     // }
-    newChat()
+    await newChat()
   }
 
   export const valueOf = (chatId: number, value: any) => {

--- a/src/lib/providers/openai/models.svelte
+++ b/src/lib/providers/openai/models.svelte
@@ -5,7 +5,7 @@
     import { getApiBase, globalStorage } from '../../Storage.svelte'
     import type { Chat, Message, Model, ModelDetail } from '../../Types.svelte'
     import { chatRequest, imageRequest } from './request.svelte'
-    import { checkModel } from './util.svelte'
+    import { checkModel, getSupportedModels } from './util.svelte'
     import { encode } from 'gpt-tokenizer'
     import { get } from 'svelte/store'
 
@@ -101,12 +101,10 @@ export const fallbackModelDetail = {
   ...chatModelBase,
   prompt: 0, // $0.00 per 1000 tokens prompt
   completion: 0, // $0.00 per 1000 tokens completion
-  max: 1024000, // 1M max token buffer
-  name: 'openchat-3.5-0106.Q5_K_M.gguf'
+  max: 1024000 // 1M max token buffer
 }
 
 export const chatModels : Record<string, ModelDetail> = {
-  'openchat-3.5-0106.Q5_K_M.gguf': { ...fallbackModelDetail },
   'gpt-3.5-turbo': { ...gpt3516k },
   'gpt-3.5-turbo-0301': { ...gpt35 },
   'gpt-3.5-turbo-0613': { ...gpt35 },
@@ -124,6 +122,19 @@ export const chatModels : Record<string, ModelDetail> = {
   'gpt-4-32k': { ...gpt432k },
   'gpt-4-32k-0314': { ...gpt432k },
   'gpt-4-32k-0613': { ...gpt432k }
+}
+
+export const fetchRemoteModels = async () => {
+  const supportedModels = await getSupportedModels()
+
+  Object.keys(supportedModels).forEach((key) => {
+        supportedModels[key] = {
+          ...chatModelBase,
+          ...supportedModels[key]
+        }
+  })
+
+  return supportedModels
 }
 
 const imageModelBase = {

--- a/src/lib/providers/openai/models.svelte
+++ b/src/lib/providers/openai/models.svelte
@@ -1,8 +1,8 @@
 <script context="module" lang="ts">
-    import { getApiBase, getEndpointCompletions, getEndpointGenerations } from '../../ApiUtil.svelte'
+    import { getEndpointCompletions, getEndpointGenerations } from '../../ApiUtil.svelte'
     import { countTokens } from '../../Models.svelte'
     import { countMessageTokens } from '../../Stats.svelte'
-    import { globalStorage } from '../../Storage.svelte'
+    import { getApiBase, globalStorage } from '../../Storage.svelte'
     import type { Chat, Message, Model, ModelDetail } from '../../Types.svelte'
     import { chatRequest, imageRequest } from './request.svelte'
     import { checkModel } from './util.svelte'
@@ -94,7 +94,18 @@ const gpt4128kpreview = {
       max: 131072 // 128k max token buffer
 }
 
+// Fallback model details for unknown models. Since we do not
+// know the pricing or context limits, we will assume a free
+// model with high limits.
+export const fallbackModelDetail = {
+  ...chatModelBase,
+  prompt: 0, // $0.00 per 1000 tokens prompt
+  completion: 0, // $0.00 per 1000 tokens completion
+  max: 1024000 // 1M max token buffer
+}
+
 export const chatModels : Record<string, ModelDetail> = {
+  'openchat-3.5-0106.Q5_K_M.gguf': { ...fallbackModelDetail },
   'gpt-3.5-turbo': { ...gpt3516k },
   'gpt-3.5-turbo-0301': { ...gpt35 },
   'gpt-3.5-turbo-0613': { ...gpt35 },

--- a/src/lib/providers/openai/models.svelte
+++ b/src/lib/providers/openai/models.svelte
@@ -101,7 +101,8 @@ export const fallbackModelDetail = {
   ...chatModelBase,
   prompt: 0, // $0.00 per 1000 tokens prompt
   completion: 0, // $0.00 per 1000 tokens completion
-  max: 1024000 // 1M max token buffer
+  max: 1024000, // 1M max token buffer
+  name: 'openchat-3.5-0106.Q5_K_M.gguf'
 }
 
 export const chatModels : Record<string, ModelDetail> = {

--- a/src/lib/providers/openai/request.svelte
+++ b/src/lib/providers/openai/request.svelte
@@ -12,7 +12,7 @@ export const chatRequest = async (
   chatResponse: ChatCompletionResponse,
   opts: ChatCompletionOpts): Promise<ChatCompletionResponse> => {
     // OpenAI Request
-      const model = chatRequest.getModel()
+      const model = await chatRequest.getModel()
       const signal = chatRequest.controller.signal
       const abortListener = (e:Event) => {
         chatRequest.updating = false

--- a/src/lib/providers/openai/util.svelte
+++ b/src/lib/providers/openai/util.svelte
@@ -1,8 +1,8 @@
 <script context="module" lang="ts">
-    import { apiKeyStorage } from '../../Storage.svelte'
+    import { apiKeyStorage, getApiBase } from '../../Storage.svelte'
     import { get } from 'svelte/store'
     import type { ModelDetail } from '../../Types.svelte'
-    import { getApiBase, getEndpointModels } from '../../ApiUtil.svelte'
+    import { getEndpointModels } from '../../ApiUtil.svelte'
 
 type ResponseModels = {
   object?: string;

--- a/src/lib/providers/openai/util.svelte
+++ b/src/lib/providers/openai/util.svelte
@@ -20,7 +20,7 @@ export const set = (opt: Record<string, any>) => {
   apiKeyStorage.set(opt.apiKey || '')
 }
 
-const getSupportedModels = async (): Promise<Record<string, boolean>> => {
+export const getSupportedModels = async (): Promise<Record<string, boolean>> => {
   if (availableModels) return availableModels
   const openAiKey = get(apiKeyStorage)
   if (!openAiKey) return {}
@@ -40,6 +40,7 @@ const getSupportedModels = async (): Promise<Record<string, boolean>> => {
         }, {})
         return availableModels
   } catch (e) {
+        console.error(e)
         availableModels = {}
         clearTimeout(_resetSupportedModelsTimer)
         _resetSupportedModelsTimer = setTimeout(() => { availableModels = undefined }, 1000)

--- a/src/lib/providers/petals/request.svelte
+++ b/src/lib/providers/petals/request.svelte
@@ -37,7 +37,7 @@ export const chatRequest = async (
       // Petals
       const chat = chatRequest.getChat()
       const chatSettings = chat.settings
-      const model = chatRequest.getModel()
+      const model = await chatRequest.getModel()
       const modelDetail = getModelDetail(model)
       const signal = chatRequest.controller.signal
       const providerData = chatRequest.providerData.petals || {}


### PR DESCRIPTION
This adds the a new input field in the API settings for an OpenAI-compatible base URI, which will allow us to use open source models hosted on our own infrastructure.

What should be noted is that there are hard-coded values in some files, which are a workaround to avoid bigger refactoring, which is currently out of scope for our ticket.